### PR TITLE
Pin ember-cli-htmlbars-inline-precompile and install Bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-code-coverage": "0.3.11",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "0.3.12",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "0.13.2",
     "ember-cli-shims": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Matthew Dahl (https://github.com/sandersky)",
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "2.12.3",
     "ember-cli-chai": "^0.3.2",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Install `Bower` as a `devDependeny` in _package.json_ since it was removed in Ember CLI 2.12 and `ember-try` seems to have issues with that
* Pin `ember-cli-htmlbars-inline-precompile` to `0.3.12`