### PR TITLE
Release fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
+# 0.8.0 (2017-12-28)
+
+We experienced an issue with our release version strategy and this release should not have occurred.  Unfortunately the release that should have (0.7.1) did then occur so we will now release version 0.8.1 to get everything back on track.
+
 # 0.7.1 (2018-01-03)
 
 * Remove _package-lock.json_ until officially support Node 8
 * Pin `ember-cli-code-coverage@0.3.12`
 * Remove useLintTree ember-cli-mocha config option
 * Upgrade `ember-frost-test` to `^4.0.0`
-
-# 0.8.0 (2017-12-28)
-
-We experienced an issue with our release version strategy and this release should not have occurred.  Unfortunately the release that should have (0.7.1) did then occur so we will now release version 0.8.1 to get everything back on track.
 
 # 0.7.0 (2017-11-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # 0.7.1 (2018-01-03)
 
-Please add a description of your change here, it will be automatically prepended to the `CHANGELOG.md` file.
 * Remove _package-lock.json_ until officially support Node 8
 * Pin `ember-cli-code-coverage@0.3.12`
 * Remove useLintTree ember-cli-mocha config option
 * Upgrade `ember-frost-test` to `^4.0.0`
+
+# 0.8.0 (2017-12-28)
+
+We experienced an issue with our release version strategy and this release should not have occurred.  Unfortunately the release that should have (0.7.1) did then occur so we will now release version 0.8.1 to get everything back on track.
 
 # 0.7.0 (2017-11-17)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-pollboy",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Ember polling service.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

We experienced an issue with our release version strategy and version `0.8.0` should not have been released.  Unfortunately the release that should have been - `0.7.1` - was then released so this PR will release `0.8.1` to get everything back on track.